### PR TITLE
Added "detonate parent"

### DIFF
--- a/GameData/TacSelfDestruct/TacSelfDestruct_v.txt
+++ b/GameData/TacSelfDestruct/TacSelfDestruct_v.txt
@@ -1,0 +1,3 @@
+﻿You have installed the TAC Self Destruct, version  ('12b7ad1'+'973167c' with modifications).
+
+See the Readme.txt and LICENSE.txt files for more information.

--- a/Readme.md
+++ b/Readme.md
@@ -1,14 +1,18 @@
 A Self Destruct from Thunder Aerospace Corporation (TAC),
-designed by Taranis Elsu.
+designed by Taranis Elsu. Slightly modified by DrSpaceMonkey.
 
 For use with the Kerbal Space Program, http://kerbalspaceprogram.com/
 
 This mod is made available under the Attribution-NonCommercial-ShareAlike 3.0 (CC
 BY-NC-SA 3.0) creative commons license. See the LICENSE.txt file.
 
-Source code is available at https://github.com/taraniselsu/TacSelfDestruct
+Source code for the original is available at https://github.com/taraniselsu/TacSelfDestruct
 
-===== Features =====
+Modified source is available at: https://github.com/DrSpaceMonkey/TacSelfDestruct
+
+### Any problems experienced with this version are not Taranis Elsu's fault. Please leave him alone if I broke something.
+
+### Features ###
 
 * Self Destruct - makes the entire vessel explode! Make sure you EVA your crew first!
 * Explode - only makes the Self Destruct part explode. Useful for creating a little
@@ -17,18 +21,23 @@ Source code is available at https://github.com/taraniselsu/TacSelfDestruct
 * Can now be activated from EVA.
 * The Self Destruct now waits 10 seconds, and goes through a countdown sequence,
       before activating.
+	  
+* Can now blow up it's parent part via the "Detonate Parent!" functionality, 
+      effectively making a decoupler out of whatever you stick it to
+* Can toggle the part's staging action between self destructing the vessel, and
+      detonating the parent part.
 
 
-===== Installation procedure =====
+### Installation procedure ### 
 
 1) Copy everything in the GameData directory to the {KSP}/GameData directory.
 
 Optional:
 Add the following lines to any part that you want to have the Self Destruct functionality:
 
-MODULE
-{
-   name = TacSelfDestruct
-   timeDelay = 10.0
-   canStage = false
-}
+     MODULE
+     {
+        name = TacSelfDestruct
+        timeDelay = 10.0
+        canStage = false
+     }

--- a/Readme.md
+++ b/Readme.md
@@ -12,7 +12,7 @@ Modified source is available at: https://github.com/DrSpaceMonkey/TacSelfDestruc
 
 ### Any problems experienced with this version are not Taranis Elsu's fault. Please leave him alone if I broke something.
 
-### Features ###
+### Features
 
 * Self Destruct - makes the entire vessel explode! Make sure you EVA your crew first!
 * Explode - only makes the Self Destruct part explode. Useful for creating a little
@@ -28,7 +28,7 @@ Modified source is available at: https://github.com/DrSpaceMonkey/TacSelfDestruc
       detonating the parent part.
 
 
-### Installation procedure ### 
+### Installation procedure 
 
 1) Copy everything in the GameData directory to the {KSP}/GameData directory.
 

--- a/Source/TacSelfDestruct.cs
+++ b/Source/TacSelfDestruct.cs
@@ -43,6 +43,9 @@ namespace Tac
         [KSPField(isPersistant = true)]
         public bool canStage = true;
 
+        [KSPField(isPersistant = true)]
+        public int stagingMode = (int)StagingMode.SelfDestruct;
+
         [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "Countdown"),
          UI_Toggle(scene = UI_Scene.All, enabledText = "", disabledText = "")]
         public bool showCountdown = true;
@@ -84,7 +87,15 @@ namespace Tac
             this.Log("Activating!");
             if (canStage && countDownInitiated == 0.0f)
             {
-                ExplodeAllEvent();
+                switch ((StagingMode)stagingMode)
+                {
+                    case StagingMode.SelfDestruct:
+                        ExplodeAllEvent();
+                        break;
+                    case StagingMode.DetonateParent:
+                        DetonateParentEvent();
+                        break;
+                }
             }
         }
 
@@ -123,8 +134,23 @@ namespace Tac
             UpdateStagingEvents();
         }
 
+        [KSPEvent(active = false, guiActive = true, guiActiveEditor = true, guiName = "Mode: Detonate Parent")]
+        public void DetonateParentOnStaging()
+        {
+            stagingMode = (int)StagingMode.SelfDestruct;
+            UpdateStagingModeEvents();
+        }
+
+        [KSPEvent(active = false, guiActive = true, guiActiveEditor = true, guiName = "Mode: Self Destruct")]
+        public void SelfDestructOnStaging()
+        {
+            stagingMode = (int)StagingMode.DetonateParent;
+            UpdateStagingModeEvents();
+        }
+
         private void UpdateStagingEvents()
         {
+            UpdateStagingModeEvents();
             if (HighLogic.LoadedSceneIsEditor)
             {
                 if (canStage)
@@ -145,6 +171,25 @@ namespace Tac
             }
         }
 
+        private void UpdateStagingModeEvents()
+        {
+            Events["DetonateParentOnStaging"].active = false;
+            Events["SelfDestructOnStaging"].active = false;
+
+            if (canStage)
+            {
+                switch ((StagingMode)stagingMode)
+                {
+                    case StagingMode.SelfDestruct:
+                        Events["SelfDestructOnStaging"].active = true;
+                        break;
+                    case StagingMode.DetonateParent:
+                        Events["DetonateParentOnStaging"].active = true;
+                        break;
+                }
+            }
+        }
+
         [KSPEvent(active = false, guiActive = true, guiActiveUnfocused = true, guiName = "Self Destruct!", unfocusedRange = 8.0f)]
         public void ExplodeAllEvent()
         {
@@ -156,6 +201,13 @@ namespace Tac
         [KSPEvent(active = false, guiActive = true, guiActiveUnfocused = true, guiName = "Explode!", unfocusedRange = 8.0f)]
         public void ExplodeEvent()
         {
+            part.explode();
+        }
+
+        [KSPEvent(active = false, guiActive = true, guiActiveUnfocused = true, guiName = "Detonate parent!", unfocusedRange = 8.0f)]
+        public void DetonateParentEvent()
+        {
+            part.parent.explode();
             part.explode();
         }
 
@@ -176,6 +228,15 @@ namespace Tac
             }
         }
 
+        [KSPAction("Detonate parent!")]
+        public void ExplodeParentAction(KSPActionParam param)
+        {
+            if (countDownInitiated == 0.0f)
+            {
+                DetonateParentEvent();
+            }
+        }
+
         [KSPAction("Explode!")]
         public void ExplodeAction(KSPActionParam param)
         {
@@ -187,11 +248,13 @@ namespace Tac
 
         private void UpdateSelfDestructEvents()
         {
+            UpdateStagingModeEvents();
             if (countDownInitiated == 0.0f)
             {
                 // countdown has not been started
                 Events["ExplodeAllEvent"].active = true;
                 Events["ExplodeEvent"].active = true;
+                Events["DetonateParentEvent"].active = true;
                 Events["AbortSelfDestruct"].active = false;
             }
             else
@@ -199,6 +262,7 @@ namespace Tac
                 // countdown has been started
                 Events["ExplodeAllEvent"].active = false;
                 Events["ExplodeEvent"].active = false;
+                Events["DetonateParentEvent"].active = false;
                 Events["AbortSelfDestruct"].active = true;
             }
         }
@@ -281,6 +345,12 @@ namespace Tac
                         remaining, ScreenMessageStyle.UPPER_CENTER);
                 }
             }
+        }
+
+        private enum StagingMode
+        {
+            SelfDestruct = 0,
+            DetonateParent = 1            
         }
     }
 }


### PR DESCRIPTION
"Detonate parent" immediately blows up the X-1100 Self Destruct and the part it is attached to. Effectively turns any object into a decoupler.

Staging action can be toggled between "Self Destruct!" and "Detonate Parent!"